### PR TITLE
Surround integer list with quotes

### DIFF
--- a/RAML/api-ja.raml
+++ b/RAML/api-ja.raml
@@ -34,21 +34,21 @@ traits:
           description: |
             |
                         [string-list:type=integer]作成したチャットに参加メンバーのうち、管理者権限にしたいユーザーのアカウントIDの配列。最低1人は指定する必要がある。
-          example: 123,542,1001
+          example: "123,542,1001"
         members_member_ids:
           displayName: メンバー権限のユーザー
           type: string
           description: |
             |
                         [string-list:type=integer]作成したチャットに参加メンバーのうち、メンバー権限にしたいユーザーのアカウントIDの配列。
-          example: 21,344
+          example: "21,344"
         members_readonly_ids:
           displayName: 閲覧のみ権限のユーザー
           type: string
           description: |
             |
                         [string-list:type=integer]作成したチャットに参加メンバーのうち、閲覧のみ権限にしたいユーザーのアカウントIDの配列。
-          example: 15,103
+          example: "15,103"
   - 
     room_icon:
       queryParameters:
@@ -1893,7 +1893,7 @@ traits:
                             [string-list:type=integer]担当者のアカウントIDをカンマ区切りで
             type: string
             required: true
-            example: 1,3,6
+            example: "1,3,6"
           limit:
             displayName: タスクの期限
             description: |


### PR DESCRIPTION
# Why?
I want to use `api-ja.raml` with ruby. 

But `Psych` (yaml parser of ruby) considers a comma separated number list (e.g. `123,542,1001`) to be a long number (`1235421001`). :cry:

# Example

```ruby
RUBY_VERSION
#=> "2.5.0"

example = YAML.load_file("RAML/api-ja.raml")["traits"][0]["room_members"]["queryParameters"]["members_admin_ids"]["example"]

example
#=> 1235421001

example.class
#=> Integer
```

# Workaround
I quoted these to explicitly treat it as a String

```ruby
example = YAML.load_file("RAML/api-ja.raml")["traits"][0]["room_members"]["queryParameters"]["members_admin_ids"]["example"]

example
#=> "123,542,1001"

example.class
#=> String
```

# Remarks
I think this behavior of Ruby is not a bug but a specification.

https://github.com/ruby/ruby/blob/v2_5_0/test/psych/visitors/test_to_ruby.rb#L203-L210